### PR TITLE
Added extended block list to dynamic memory tracker

### DIFF
--- a/mbed-client-libservice/nsdynmem_tracker_lib.h
+++ b/mbed-client-libservice/nsdynmem_tracker_lib.h
@@ -29,17 +29,28 @@ extern "C" {
 
 #if NSDYNMEM_TRACKER_ENABLED==1
 
+// Memory block structure with caller information
 typedef struct ns_dyn_mem_tracker_lib_mem_blocks_s {
     void *block;                   /**< Allocated memory block */
     void *caller_addr;             /**< Caller address */
     uint32_t size;                 /**< Allocation size */
+    uint32_t total_size;           /**< Total allocation size for all allocations */
     uint32_t lifetime;             /**< Memory block lifetime in steps (e.g. seconds) */
+    uint32_t ref_count;            /**< Reference count */
     const char *function;          /**< Caller function */
     uint16_t line;                 /**< Caller line in module */
     bool permanent : 1;            /**< Permanent memory block */
     bool permanent_printed : 1;    /**< Permanent memory block printed */
 } ns_dyn_mem_tracker_lib_mem_blocks_t;
 
+// Extended memory block structure that is used if same caller allocates multiple memory blocks
+typedef struct ns_dyn_mem_tracker_lib_mem_blocks_ext_s {
+    void *block;                   /**< Allocated memory block */
+    void *caller_addr;             /**< Caller address */
+    uint32_t size;                 /**< Allocation size */
+} ns_dyn_mem_tracker_lib_mem_blocks_ext_t;
+
+// Allocator information structure
 typedef struct ns_dyn_mem_tracker_lib_allocators_s {
     void *caller_addr;             /**< Caller address */
     uint32_t alloc_count;          /**< Number of allocations */
@@ -51,22 +62,30 @@ typedef struct ns_dyn_mem_tracker_lib_allocators_s {
 
 // Memory block array allocator / array size increase allocator
 typedef ns_dyn_mem_tracker_lib_mem_blocks_t *ns_dyn_mem_tracker_lib_alloc_mem_blocks(ns_dyn_mem_tracker_lib_mem_blocks_t *blocks, uint16_t *mem_blocks_count);
+// Extended memory block array allocator / array size increase allocator
+typedef ns_dyn_mem_tracker_lib_mem_blocks_ext_t *ns_dyn_mem_tracker_lib_alloc_mem_blocks_ext(ns_dyn_mem_tracker_lib_mem_blocks_ext_t *blocks, uint32_t *mem_blocks_count);
+// Extended memory block array index hash function to get memory block (allocation/search start) index from block address
+typedef uint32_t ns_dyn_mem_tracker_lib_mem_block_index_hash(void *block, uint32_t ext_mem_blocks_count);
 
 typedef struct ns_dyn_mem_tracker_lib_conf_s {
-    ns_dyn_mem_tracker_lib_mem_blocks_t *mem_blocks;                /**< Memory blocks array, if NULL calls allocator on init */
-    ns_dyn_mem_tracker_lib_allocators_t *top_allocators;            /**< Top allocators array */
-    ns_dyn_mem_tracker_lib_allocators_t *permanent_allocators;      /**< Permanent allocators */
-    ns_dyn_mem_tracker_lib_allocators_t *to_permanent_allocators;   /**< To permanent allocators */
-    ns_dyn_mem_tracker_lib_allocators_t *max_snap_shot_allocators;  /**< Snap shot of maximum memory used by allocators */
-    ns_dyn_mem_tracker_lib_alloc_mem_blocks *alloc_mem_blocks;      /**< Memory block array allocator / array size increase allocator */
-    uint32_t allocated_memory;                                      /**< Currently allocated memory */
-    uint16_t mem_blocks_count;                                      /**< Number of entries in memory blocks array */
-    uint16_t last_mem_block_index;                                  /**< Last memory block in memory blocks array */
-    uint16_t top_allocators_count;                                  /**< Top allocators array count */
-    uint16_t permanent_allocators_count;                            /**< Permanent allocators array count */
-    uint16_t to_permanent_allocators_count;                         /**< To permanent allocators array count */
-    uint16_t max_snap_shot_allocators_count;                        /**< Snap shot of maximum memory used by allocators array count */
-    uint16_t to_permanent_steps_count;                              /**< How many steps before moving block to permanent allocators list */
+    ns_dyn_mem_tracker_lib_mem_blocks_t *mem_blocks;                    /**< Memory blocks array, if NULL calls allocator on init */
+    ns_dyn_mem_tracker_lib_mem_blocks_ext_t *ext_mem_blocks;            /**< Extended memory blocks array, if NULL calls allocator on init */
+    ns_dyn_mem_tracker_lib_allocators_t *top_allocators;                /**< Top allocators array */
+    ns_dyn_mem_tracker_lib_allocators_t *permanent_allocators;          /**< Permanent allocators */
+    ns_dyn_mem_tracker_lib_allocators_t *to_permanent_allocators;       /**< To permanent allocators */
+    ns_dyn_mem_tracker_lib_allocators_t *max_snap_shot_allocators;      /**< Snap shot of maximum memory used by allocators */
+    ns_dyn_mem_tracker_lib_alloc_mem_blocks *alloc_mem_blocks;          /**< Memory block array allocator / array size increase allocator */
+    ns_dyn_mem_tracker_lib_alloc_mem_blocks_ext *ext_alloc_mem_blocks;  /**< Extended memory block array allocator / array size increase allocator */
+    ns_dyn_mem_tracker_lib_mem_block_index_hash *block_index_hash;      /**< Hash function to get memory block index from block address */
+    uint32_t allocated_memory;                                          /**< Currently allocated memory */
+    uint16_t mem_blocks_count;                                          /**< Number of entries in memory blocks array */
+    uint32_t ext_mem_blocks_count;                                      /**< Number of entries in extended memory blocks array */
+    uint16_t last_mem_block_index;                                      /**< Last memory block in memory blocks array */
+    uint16_t top_allocators_count;                                      /**< Top allocators array count */
+    uint16_t permanent_allocators_count;                                /**< Permanent allocators array count */
+    uint16_t to_permanent_allocators_count;                             /**< To permanent allocators array count */
+    uint16_t max_snap_shot_allocators_count;                            /**< Snap shot of maximum memory used by allocators array count */
+    uint16_t to_permanent_steps_count;                                  /**< How many steps before moving block to permanent allocators list */
 } ns_dyn_mem_tracker_lib_conf_t;
 
 int8_t ns_dyn_mem_tracker_lib_alloc(ns_dyn_mem_tracker_lib_conf_t *conf, void *caller_addr, const char *function, uint32_t line, void *block, uint32_t alloc_size);

--- a/source/nsdynmemtracker/nsdynmem_tracker_lib.c
+++ b/source/nsdynmemtracker/nsdynmem_tracker_lib.c
@@ -248,13 +248,9 @@ int8_t ns_dyn_mem_tracker_lib_allocator_lists_update(ns_dyn_mem_tracker_lib_conf
     // Maximum to print of permanent entries
     uint8_t permanent_count = 0;
 
-    uint32_t list_allocated_memory = 0;
-
     for (uint32_t index = 0; index <= conf->last_mem_block_index; index++) {
         if (blocks[index].block != NULL) {
             void *caller_addr = blocks[index].caller_addr;
-
-            list_allocated_memory += blocks[index].total_size;
 
             // Checks if caller address has already been counted
             bool next = false;
@@ -318,10 +314,6 @@ int8_t ns_dyn_mem_tracker_lib_allocator_lists_update(ns_dyn_mem_tracker_lib_conf
                 }
             }
         }
-    }
-
-    if (conf->allocated_memory != list_allocated_memory) {
-        return -1;
     }
 
     if (permanent_count < permanent_allocators_count) {

--- a/source/nsdynmemtracker/nsdynmem_tracker_lib.c
+++ b/source/nsdynmemtracker/nsdynmem_tracker_lib.c
@@ -23,9 +23,12 @@
 
 #if NSDYNMEM_TRACKER_ENABLED==1
 
-static int8_t ns_dyn_mem_tracker_lib_find_free_index(ns_dyn_mem_tracker_lib_conf_t *conf, uint32_t *index);
-static void ns_dyn_mem_tracker_lib_permanent_value_set(ns_dyn_mem_tracker_lib_conf_t *conf, void *caller_addr, bool new_value);
+static int8_t ns_dyn_mem_tracker_lib_find_free_index(ns_dyn_mem_tracker_lib_conf_t *conf, uint16_t *index);
+static int8_t ns_dyn_mem_tracker_lib_find_caller_index(ns_dyn_mem_tracker_lib_conf_t *conf, void *caller_addr, uint16_t *caller_index);
+static int8_t ns_dyn_mem_tracker_lib_find_block_index(ns_dyn_mem_tracker_lib_conf_t *conf, void *block, uint16_t *block_index);
+static int8_t ns_dyn_mem_tracker_lib_ext_find_free_index(ns_dyn_mem_tracker_lib_conf_t *conf, uint32_t start_index, uint32_t *free_index);
 static void ns_dyn_mem_tracker_lib_permanent_printed_value_set(ns_dyn_mem_tracker_lib_conf_t *conf, void *caller_addr, bool new_value);
+static int8_t ns_dyn_mem_tracker_lib_ext_find_block_index(ns_dyn_mem_tracker_lib_conf_t *conf, void *block, uint32_t start_index, uint32_t *block_index);
 
 int8_t ns_dyn_mem_tracker_lib_alloc(ns_dyn_mem_tracker_lib_conf_t *conf, void *caller_addr, const char *function, uint32_t line, void *block, uint32_t alloc_size)
 {
@@ -45,24 +48,64 @@ int8_t ns_dyn_mem_tracker_lib_alloc(ns_dyn_mem_tracker_lib_conf_t *conf, void *c
         }
     }
 
-    uint32_t free_index = 0;
+    uint16_t caller_index = 0;
+    if (ns_dyn_mem_tracker_lib_find_caller_index(conf, caller_addr, &caller_index) >= 0) {
+        if (conf->ext_mem_blocks == NULL) {
+            conf->ext_mem_blocks = conf->ext_alloc_mem_blocks(conf->ext_mem_blocks, &conf->ext_mem_blocks_count);
+            if (conf->ext_mem_blocks == NULL) {
+                platform_exit_critical();
+                return -1;
+            }
+        }
+
+        uint32_t free_index = 0;
+        uint32_t start_index = 0;
+        if (conf->block_index_hash != NULL) {
+            start_index = conf->block_index_hash(block, conf->ext_mem_blocks_count);
+        }
+        if (ns_dyn_mem_tracker_lib_ext_find_free_index(conf, start_index, &free_index) < 0) {
+            conf->ext_mem_blocks = conf->ext_alloc_mem_blocks(conf->ext_mem_blocks, &conf->ext_mem_blocks_count);
+            if (conf->block_index_hash != NULL) {
+                start_index = conf->block_index_hash(block, conf->ext_mem_blocks_count);
+            }
+            if (conf->ext_mem_blocks == NULL || (ns_dyn_mem_tracker_lib_ext_find_free_index(conf, start_index, &free_index) < 0)) {
+                platform_exit_critical();
+                return -1;
+            }
+        }
+
+        // Updates memory blocks array entry
+        conf->mem_blocks[caller_index].ref_count++;
+        conf->mem_blocks[caller_index].total_size += alloc_size;
+        conf->mem_blocks[caller_index].lifetime = 0;
+        conf->mem_blocks[caller_index].permanent = false;
+        conf->mem_blocks[caller_index].permanent_printed = false;
+
+        conf->ext_mem_blocks[free_index].block = block;
+        conf->ext_mem_blocks[free_index].caller_addr = caller_addr;
+        conf->ext_mem_blocks[free_index].size = alloc_size;
+
+        conf->allocated_memory += alloc_size;
+
+        platform_exit_critical();
+        return 0;
+    }
+
+    uint16_t free_index = 0;
     if (ns_dyn_mem_tracker_lib_find_free_index(conf, &free_index) < 0) {
         conf->mem_blocks = conf->alloc_mem_blocks(conf->mem_blocks, &conf->mem_blocks_count);
-        if (conf->mem_blocks == NULL) {
+        if (conf->mem_blocks == NULL || (ns_dyn_mem_tracker_lib_find_free_index(conf, &free_index) < 0)) {
             platform_exit_critical();
             return -1;
         }
     }
 
-    if (ns_dyn_mem_tracker_lib_find_free_index(conf, &free_index) < 0) {
-        platform_exit_critical();
-        return -1;
-    }
-
     conf->mem_blocks[free_index].block = block;
     conf->mem_blocks[free_index].caller_addr = caller_addr;
     conf->mem_blocks[free_index].size = alloc_size;
+    conf->mem_blocks[free_index].total_size = alloc_size;
     conf->mem_blocks[free_index].lifetime = 0;
+    conf->mem_blocks[free_index].ref_count = 1;
     conf->mem_blocks[free_index].function = function;
     conf->mem_blocks[free_index].line = line;
     conf->mem_blocks[free_index].permanent = false;
@@ -74,10 +117,6 @@ int8_t ns_dyn_mem_tracker_lib_alloc(ns_dyn_mem_tracker_lib_conf_t *conf, void *c
 
     conf->allocated_memory += alloc_size;
 
-    // Sets all allocations for the caller not permanent, since new allocation
-    ns_dyn_mem_tracker_lib_permanent_value_set(conf, caller_addr, false);
-    ns_dyn_mem_tracker_lib_permanent_printed_value_set(conf, caller_addr, false);
-
     platform_exit_critical();
 
     return 0;
@@ -87,6 +126,7 @@ int8_t ns_dyn_mem_tracker_lib_free(ns_dyn_mem_tracker_lib_conf_t *conf, void *ca
 {
     (void) function;
     (void) line;
+    (void) caller_addr;
 
     // No memory block or no allocations made
     if (block == NULL || conf->mem_blocks == NULL) {
@@ -95,44 +135,83 @@ int8_t ns_dyn_mem_tracker_lib_free(ns_dyn_mem_tracker_lib_conf_t *conf, void *ca
 
     platform_enter_critical();
 
-    bool block_freed = false;
-
-    for (uint32_t index = 0; index <= conf->last_mem_block_index; index++) {
-        if (conf->mem_blocks[index].block == block) {
-            conf->allocated_memory -= conf->mem_blocks[index].size;
-
-            conf->mem_blocks[index].block = NULL;
-            conf->mem_blocks[index].caller_addr = NULL;
-            conf->mem_blocks[index].size = 0;
-            conf->mem_blocks[index].lifetime = 0;
-            conf->mem_blocks[index].function = NULL;
-            conf->mem_blocks[index].line = 0;
-            conf->mem_blocks[index].permanent = false;
-            conf->mem_blocks[index].permanent_printed = false;
-
-            if (conf->last_mem_block_index == index) {
-                for (uint32_t prev_index = conf->last_mem_block_index; prev_index > 0; prev_index--) {
-                    if (conf->mem_blocks[prev_index].block != NULL) {
-                        conf->last_mem_block_index = prev_index;
-                        break;
-                    }
-                }
-            }
-
-            block_freed = true;
-
-            // Sets all allocations for the caller not permanent, since new free
-            ns_dyn_mem_tracker_lib_permanent_value_set(conf, caller_addr, false);
-            ns_dyn_mem_tracker_lib_permanent_printed_value_set(conf, caller_addr, false);
-            break;
+    uint16_t block_index = 0;
+    if (ns_dyn_mem_tracker_lib_find_block_index(conf, block, &block_index) >= 0) {
+        // If last block for allocator clears the allocator
+        if (conf->mem_blocks[block_index].ref_count <= 1) {
+            conf->mem_blocks[block_index].ref_count = 0;
+            conf->mem_blocks[block_index].caller_addr = NULL;
+            conf->mem_blocks[block_index].total_size = 0;
+            conf->mem_blocks[block_index].function = NULL;
+            conf->mem_blocks[block_index].line = 0;
+        } else {
+            // Other blocks exists
+            conf->mem_blocks[block_index].ref_count--;
+            conf->mem_blocks[block_index].total_size -= conf->mem_blocks[block_index].size;
         }
+
+        conf->allocated_memory -= conf->mem_blocks[block_index].size;
+
+        // Clears block specific fields
+        conf->mem_blocks[block_index].block = NULL;
+        conf->mem_blocks[block_index].size = 0;
+        // Resets lifetime and permanent settings
+        conf->mem_blocks[block_index].lifetime = 0;
+        conf->mem_blocks[block_index].permanent = false;
+        conf->mem_blocks[block_index].permanent_printed = false;
+
+        platform_exit_critical();
+        return 0;
+    }
+
+    if (conf->ext_mem_blocks == NULL) {
+        return -1;
+    }
+
+    uint32_t ext_block_index = 0;
+    uint32_t start_index = 0;
+    if (conf->block_index_hash != NULL) {
+        start_index = conf->block_index_hash(block, conf->ext_mem_blocks_count);
+    }
+    if (ns_dyn_mem_tracker_lib_ext_find_block_index(conf, block, start_index, &ext_block_index) < 0) {
+        platform_exit_critical();
+        return -1;
+    }
+
+    void *ext_caller_addr = conf->ext_mem_blocks[ext_block_index].caller_addr;
+
+    uint16_t caller_index;
+    if (ns_dyn_mem_tracker_lib_find_caller_index(conf, ext_caller_addr, &caller_index) < 0) {
+        platform_exit_critical();
+        return -1;
+    }
+
+    conf->mem_blocks[caller_index].ref_count--;
+    conf->mem_blocks[caller_index].total_size -= conf->ext_mem_blocks[ext_block_index].size;
+
+    conf->allocated_memory -= conf->ext_mem_blocks[ext_block_index].size;
+
+    // Clears extended block
+    conf->ext_mem_blocks[ext_block_index].block = NULL;
+    conf->ext_mem_blocks[ext_block_index].caller_addr = NULL;
+    conf->ext_mem_blocks[ext_block_index].size = 0;
+
+    // Resets lifetime and permanent settings
+    conf->mem_blocks[block_index].lifetime = 0;
+    conf->mem_blocks[block_index].permanent = false;
+    conf->mem_blocks[block_index].permanent_printed = false;
+
+    // If last block for allocator clears the allocator
+    if (conf->mem_blocks[block_index].ref_count == 0) {
+        conf->mem_blocks[block_index].block = NULL;
+        conf->mem_blocks[block_index].caller_addr = NULL;
+        conf->mem_blocks[block_index].size = 0;
+        conf->mem_blocks[block_index].total_size = 0;
+        conf->mem_blocks[block_index].function = NULL;
+        conf->mem_blocks[block_index].line = 0;
     }
 
     platform_exit_critical();
-
-    if (!block_freed) {
-        return -1;
-    }
 
     return 0;
 }
@@ -175,7 +254,7 @@ int8_t ns_dyn_mem_tracker_lib_allocator_lists_update(ns_dyn_mem_tracker_lib_conf
         if (blocks[index].block != NULL) {
             void *caller_addr = blocks[index].caller_addr;
 
-            list_allocated_memory += blocks[index].size;
+            list_allocated_memory += blocks[index].total_size;
 
             // Checks if caller address has already been counted
             bool next = false;
@@ -190,53 +269,29 @@ int8_t ns_dyn_mem_tracker_lib_allocator_lists_update(ns_dyn_mem_tracker_lib_conf
                 continue;
             }
 
-            /* Search for all the references to the caller address from the allocation info and
-               store allocation count, total memory for all allocations and shortest counter */
-            uint32_t alloc_count = 0;
-            uint32_t total_memory = 0;
-            uint32_t min_lifetime = ~0;
-            bool permanent_set_on_all = true;
-            bool permanent_printed_set_on_all = true;
-            for (uint32_t search_index = 0; search_index <= conf->last_mem_block_index; search_index++) {
-                if (caller_addr == blocks[search_index].caller_addr) {
-                    alloc_count++;
-                    total_memory += blocks[search_index].size;
-                    if (blocks[search_index].lifetime < min_lifetime) {
-                        min_lifetime = blocks[search_index].lifetime;
-                    }
-                    if (!blocks[search_index].permanent) {
-                        permanent_set_on_all = false;
-                    }
-                    if (!blocks[search_index].permanent_printed) {
-                        permanent_printed_set_on_all = false;
-                    }
-
-                }
-            }
-
             // Checks whether all reference are marked permanent
-            if (permanent_set_on_all) {
-                if (!permanent_printed_set_on_all && permanent_count < permanent_allocators_count) {
+            if (blocks[index].permanent) {
+                if (!blocks[index].permanent_printed && permanent_count < permanent_allocators_count) {
                     permanent_allocators[permanent_count].caller_addr = caller_addr;
-                    permanent_allocators[permanent_count].alloc_count = alloc_count;
-                    permanent_allocators[permanent_count].total_memory = total_memory;
-                    permanent_allocators[permanent_count].min_lifetime = min_lifetime;
+                    permanent_allocators[permanent_count].alloc_count = blocks[index].ref_count;
+                    permanent_allocators[permanent_count].total_memory = blocks[index].total_size;
+                    permanent_allocators[permanent_count].min_lifetime = blocks[index].lifetime;
                     permanent_allocators[permanent_count].function = blocks[index].function;
                     permanent_allocators[permanent_count].line = blocks[index].line;
 
                     permanent_count++;
-                    ns_dyn_mem_tracker_lib_permanent_printed_value_set(conf, caller_addr, true);
+                    blocks[index].permanent_printed = true;
                 }
                 continue;
             } else {
                 // Checks whether lifetime threshold has been reached, traces and skips
-                if (min_lifetime > conf->to_permanent_steps_count && to_permanent_count < to_permanent_allocators_count) {
-                    ns_dyn_mem_tracker_lib_permanent_value_set(conf, caller_addr, true);
+                if (blocks[index].lifetime > conf->to_permanent_steps_count && to_permanent_count < to_permanent_allocators_count) {
+                    blocks[index].permanent = true;
 
                     to_permanent_allocators[to_permanent_count].caller_addr = caller_addr;
-                    to_permanent_allocators[to_permanent_count].alloc_count = alloc_count;
-                    to_permanent_allocators[to_permanent_count].total_memory = total_memory;
-                    to_permanent_allocators[to_permanent_count].min_lifetime = min_lifetime;
+                    to_permanent_allocators[to_permanent_count].alloc_count = blocks[index].ref_count;
+                    to_permanent_allocators[to_permanent_count].total_memory = blocks[index].total_size;
+                    to_permanent_allocators[to_permanent_count].min_lifetime = blocks[index].lifetime;
                     to_permanent_allocators[to_permanent_count].function = blocks[index].function;
                     to_permanent_allocators[to_permanent_count].line = blocks[index].line;
 
@@ -247,16 +302,16 @@ int8_t ns_dyn_mem_tracker_lib_allocator_lists_update(ns_dyn_mem_tracker_lib_conf
 
             // Add to list if allocation count is larger than entry on the list
             for (uint16_t list_index = 0; list_index < top_allocators_count; list_index++) {
-                if (alloc_count >= top_allocators[list_index].alloc_count) {
+                if (blocks[index].ref_count >= top_allocators[list_index].alloc_count) {
                     if (list_index != (top_allocators_count - 1)) {
                         uint8_t index_count = (top_allocators_count - list_index - 1);
                         uint32_t size = index_count * sizeof(ns_dyn_mem_tracker_lib_allocators_t);
                         memmove(&top_allocators[list_index + 1], &top_allocators[list_index], size);
                     }
                     top_allocators[list_index].caller_addr = caller_addr;
-                    top_allocators[list_index].alloc_count = alloc_count;
-                    top_allocators[list_index].total_memory = total_memory;
-                    top_allocators[list_index].min_lifetime = min_lifetime;
+                    top_allocators[list_index].alloc_count = blocks[index].ref_count;
+                    top_allocators[list_index].total_memory = blocks[index].total_size;
+                    top_allocators[list_index].min_lifetime = blocks[index].lifetime;
                     top_allocators[list_index].function = blocks[index].function;
                     top_allocators[list_index].line = blocks[index].line;
                     break;
@@ -302,49 +357,23 @@ void ns_dyn_mem_tracker_lib_max_snap_shot_update(ns_dyn_mem_tracker_lib_conf_t *
                 continue;
             }
 
-            /* Search for all the references to the caller address from the allocation info and
-               store allocation count, total memory for all allocations and shortest counter */
-            uint32_t alloc_count = 0;
-            uint32_t total_memory = 0;
-            uint32_t min_lifetime = ~0;
-            for (uint32_t search_index = 0; search_index <= conf->last_mem_block_index; search_index++) {
-                if (caller_addr == blocks[search_index].caller_addr) {
-                    alloc_count++;
-                    total_memory += blocks[search_index].size;
-                    if (blocks[search_index].lifetime < min_lifetime) {
-                        min_lifetime = blocks[search_index].lifetime;
-                    }
-                }
-            }
-
             // Add to list if allocation count is larger than entry on the list
             for (uint16_t list_index = 0; list_index < max_snap_shot_allocators_count; list_index++) {
-                if (total_memory >= max_snap_shot_allocators[list_index].total_memory) {
+                if (blocks[index].total_size >= max_snap_shot_allocators[list_index].total_memory) {
                     if (list_index != (max_snap_shot_allocators_count - 1)) {
                         uint8_t index_count = (max_snap_shot_allocators_count - list_index - 1);
                         uint32_t size = index_count * sizeof(ns_dyn_mem_tracker_lib_allocators_t);
                         memmove(&max_snap_shot_allocators[list_index + 1], &max_snap_shot_allocators[list_index], size);
                     }
-                    max_snap_shot_allocators[list_index].caller_addr = caller_addr;
-                    max_snap_shot_allocators[list_index].alloc_count = alloc_count;
-                    max_snap_shot_allocators[list_index].total_memory = total_memory;
-                    max_snap_shot_allocators[list_index].min_lifetime = min_lifetime;
+                    max_snap_shot_allocators[list_index].caller_addr = blocks[index].caller_addr;
+                    max_snap_shot_allocators[list_index].alloc_count = blocks[index].ref_count;
+                    max_snap_shot_allocators[list_index].total_memory = blocks[index].total_size;
+                    max_snap_shot_allocators[list_index].min_lifetime = blocks[index].lifetime;
                     max_snap_shot_allocators[list_index].function = blocks[index].function;
                     max_snap_shot_allocators[list_index].line = blocks[index].line;
                     break;
                 }
             }
-        }
-    }
-}
-
-static void ns_dyn_mem_tracker_lib_permanent_value_set(ns_dyn_mem_tracker_lib_conf_t *conf, void *caller_addr, bool new_value)
-{
-    /* Search for all the references to the caller address from the allocation info and
-       set block permanent value */
-    for (uint16_t search_index = 0; search_index <= conf->last_mem_block_index; search_index++) {
-        if (conf->mem_blocks[search_index].caller_addr == caller_addr) {
-            conf->mem_blocks[search_index].permanent = new_value;
         }
     }
 }
@@ -360,14 +389,82 @@ static void ns_dyn_mem_tracker_lib_permanent_printed_value_set(ns_dyn_mem_tracke
     }
 }
 
-static int8_t ns_dyn_mem_tracker_lib_find_free_index(ns_dyn_mem_tracker_lib_conf_t *conf, uint32_t *free_index)
+static int8_t ns_dyn_mem_tracker_lib_find_free_index(ns_dyn_mem_tracker_lib_conf_t *conf, uint16_t *free_index)
 {
-    for (uint32_t index = 0; index < conf->mem_blocks_count; index++) {
-        if (conf->mem_blocks[index].block == NULL) {
+    for (uint16_t index = 0; index < conf->mem_blocks_count; index++) {
+        if (conf->mem_blocks[index].caller_addr == NULL) {
             *free_index = index;
             return 0;
         }
     }
+    return -1;
+}
+
+static int8_t ns_dyn_mem_tracker_lib_find_caller_index(ns_dyn_mem_tracker_lib_conf_t *conf, void *caller_addr, uint16_t *caller_index)
+{
+    for (uint16_t index = 0; index <= conf->last_mem_block_index; index++) {
+        if (conf->mem_blocks[index].caller_addr == caller_addr) {
+            *caller_index = index;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static int8_t ns_dyn_mem_tracker_lib_find_block_index(ns_dyn_mem_tracker_lib_conf_t *conf, void *block, uint16_t *block_index)
+{
+    for (uint16_t index = 0; index <= conf->last_mem_block_index; index++) {
+        if (conf->mem_blocks[index].block == block) {
+            *block_index = index;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static int8_t ns_dyn_mem_tracker_lib_ext_find_free_index(ns_dyn_mem_tracker_lib_conf_t *conf, uint32_t start_index, uint32_t *free_index)
+{
+    for (uint32_t index = start_index; index < conf->ext_mem_blocks_count; index++) {
+        if (conf->ext_mem_blocks[index].caller_addr == NULL) {
+            *free_index = index;
+            return 0;
+        }
+    }
+
+    if (start_index == 0) {
+        return -1;
+    }
+
+    for (uint32_t index = 0; index < start_index; index++) {
+        if (conf->ext_mem_blocks[index].caller_addr == NULL) {
+            *free_index = index;
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+static int8_t ns_dyn_mem_tracker_lib_ext_find_block_index(ns_dyn_mem_tracker_lib_conf_t *conf, void *block, uint32_t start_index, uint32_t *block_index)
+{
+    for (uint32_t index = start_index; index < conf->ext_mem_blocks_count; index++) {
+        if (conf->ext_mem_blocks[index].block == block) {
+            *block_index = index;
+            return 0;
+        }
+    }
+
+    if (start_index == 0) {
+        return -1;
+    }
+
+    for (uint32_t index = 0; index < start_index; index++) {
+        if (conf->ext_mem_blocks[index].block == block) {
+            *block_index = index;
+            return 0;
+        }
+    }
+
     return -1;
 }
 


### PR DESCRIPTION
If same allocator (alloc call) allocates multiple dynamic memory blocks,
the additional blocks are added to extended memory block list, and
the allocator list reference count and total sizes are increased.
When statistics are calculated, it is only needed to process the
allocator list, not the whole memory block list.

Added also optional hash function to calculate the (start) index where
memory block information is stored on extended memory block list. Hash
is calculated from memory block address.

It is expected that hash distributes the free index searches evenly
to whole memory area allocated for extended memory block list. So if
area is large enough, in most cases the index pointed by the hash, or
the index few indexes from that, should be empty and available for use.
Similarly, when memory block is freed, the search for the block on
the extended memory block list, starts from the index pointed by the
hash.

If hash is not used, extended memory block list searches start always
from index 0.