### PR TITLE
Cmake add interface lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,129 +30,131 @@ target_include_directories(nanostack-libservice PUBLIC ${nanostack-libservice_SO
 target_include_directories(nanostack-libservice PUBLIC ${nanostack-libservice_SOURCE_DIR}/mbed-client-libservice)
 target_include_directories(nanostack-libservice PUBLIC ${nanostack-libservice_SOURCE_DIR}/mbed-client-libservice/platform)
 
-# Tests after this line
-enable_testing()
+if (test_all OR ${CMAKE_PROJECT_NAME} STREQUAL "nanostack-libservice")
+    # Tests after this line
+    enable_testing()
 
-if (enable_coverage_data)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
-endif ()
+    if (enable_coverage_data)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+    endif ()
 
-add_executable(ip6tos_test EXCLUDE_FROM_ALL
-    source/libip6string/ip6tos.c
-    source/libBits/common_functions.c
-    test/ip6tos/ip6tos_test.cpp
-)
-# make check, this must be after add_executable!
-add_test(ip6tos_test ip6tos_test)
-if (TARGET check)
-    add_dependencies(check ip6tos_test)
-else()
-    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
-                  DEPENDS ip6tos_test)
-endif()
-
-target_include_directories(ip6tos_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice)
-target_include_directories(ip6tos_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice/platform)
-
-target_link_libraries(
-    ip6tos_test
-    gtest_main
-)
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/test/stubs)
-
-add_executable(stoip6_test EXCLUDE_FROM_ALL
-    source/libip6string/stoip6.c
-    source/libBits/common_functions.c
-    test/stoip6/stoip6_test.cpp
-)
-# make check, this must be after add_executable!
-add_test(stoip6_test stoip6_test)
-if (TARGET check)
-    add_dependencies(check stoip6_test)
-else()
-    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
-                  DEPENDS stoip6_test)
-endif()
-
-target_include_directories(stoip6_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice)
-target_include_directories(stoip6_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice/platform)
-
-target_link_libraries(
-    stoip6_test
-    gtest_main
-)
-
-add_executable(dynmem_test EXCLUDE_FROM_ALL
-    source/nsdynmemLIB/nsdynmemLIB.c
-    test/nsdynmem/dynmem_test.cpp
-    test/nsdynmem/error_callback.c
-    test/nsdynmem/error_callback.h
-    test/stubs/platform_critical.c
-    test/stubs/ns_list_stub.c
-)
-# make check, this must be after add_executable!
-add_test(dynmem_test dynmem_test)
-if (TARGET check)
-    add_dependencies(check dynmem_test)
-else()
-    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
-                  DEPENDS dynmem_test)
-endif()
-
-target_include_directories(dynmem_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice)
-target_include_directories(dynmem_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice/platform)
-
-target_link_libraries(
-    dynmem_test
-    gtest_main
-)
-
-add_executable(nsnvmhelper_test EXCLUDE_FROM_ALL
-    source/nvmHelper/ns_nvm_helper.c
-    test/nsnvmhelper/nsnvmhelper_test.cpp
-    test/nsnvmhelper/test_ns_nvm_helper.c
-    test/nsnvmhelper/test_ns_nvm_helper.h
-    test/stubs/platform_nvm_stub.c
-    test/stubs/nsdynmemLIB_stub.c
-    test/stubs/ns_list_stub.c
-)
-# make check, this must be after add_executable!
-add_test(nsnvmhelper_test nsnvmhelper_test)
-if (TARGET check)
-    add_dependencies(check nsnvmhelper_test)
-else()
-    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
-                  DEPENDS nsnvmhelper_test)
-endif()
-
-target_include_directories(nsnvmhelper_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice)
-target_include_directories(nsnvmhelper_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice/platform)
-
-target_link_libraries(
-    nsnvmhelper_test
-    gtest_main
-)
-
-# GTest framework requires C++ version 11
-set_target_properties(dynmem_test ip6tos_test stoip6_test nsnvmhelper_test
-PROPERTIES
-    CXX_STANDARD 11
-)
-
-include(GoogleTest)
-gtest_discover_tests(ip6tos_test EXTRA_ARGS --gtest_output=xml: XML_OUTPUT_DIR ip6tos)
-gtest_discover_tests(stoip6_test EXTRA_ARGS --gtest_output=xml: XML_OUTPUT_DIR stoip6)
-gtest_discover_tests(dynmem_test EXTRA_ARGS --gtest_output=xml: XML_OUTPUT_DIR nsdynmem)
-gtest_discover_tests(nsnvmhelper_test EXTRA_ARGS --gtest_output=xml: XML_OUTPUT_DIR nvmhelper)
-
-if (enable_coverage_data AND ${CMAKE_PROJECT_NAME} STREQUAL "nanostack-libservice")
-    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html")
-
-    add_test(NAME ls_cov WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND ${BASH} -c "gcovr -r . -e ${CMAKE_CURRENT_SOURCE_DIR}/build -e '.*test.*' --html --html-details -o build/html/coverity_index.html"
+    add_executable(ip6tos_test EXCLUDE_FROM_ALL
+        source/libip6string/ip6tos.c
+        source/libBits/common_functions.c
+        test/ip6tos/ip6tos_test.cpp
     )
-endif ()
+    # make check, this must be after add_executable!
+    add_test(ip6tos_test ip6tos_test)
+    if (TARGET check)
+        add_dependencies(check ip6tos_test)
+    else()
+        add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
+                    DEPENDS ip6tos_test)
+    endif()
+
+    target_include_directories(ip6tos_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice)
+    target_include_directories(ip6tos_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice/platform)
+
+    target_link_libraries(
+        ip6tos_test
+        gtest_main
+    )
+
+    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/test/stubs)
+
+    add_executable(stoip6_test EXCLUDE_FROM_ALL
+        source/libip6string/stoip6.c
+        source/libBits/common_functions.c
+        test/stoip6/stoip6_test.cpp
+    )
+    # make check, this must be after add_executable!
+    add_test(stoip6_test stoip6_test)
+    if (TARGET check)
+        add_dependencies(check stoip6_test)
+    else()
+        add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
+                    DEPENDS stoip6_test)
+    endif()
+
+    target_include_directories(stoip6_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice)
+    target_include_directories(stoip6_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice/platform)
+
+    target_link_libraries(
+        stoip6_test
+        gtest_main
+    )
+
+    add_executable(dynmem_test EXCLUDE_FROM_ALL
+        source/nsdynmemLIB/nsdynmemLIB.c
+        test/nsdynmem/dynmem_test.cpp
+        test/nsdynmem/error_callback.c
+        test/nsdynmem/error_callback.h
+        test/stubs/platform_critical.c
+        test/stubs/ns_list_stub.c
+    )
+    # make check, this must be after add_executable!
+    add_test(dynmem_test dynmem_test)
+    if (TARGET check)
+        add_dependencies(check dynmem_test)
+    else()
+        add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
+                    DEPENDS dynmem_test)
+    endif()
+
+    target_include_directories(dynmem_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice)
+    target_include_directories(dynmem_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice/platform)
+
+    target_link_libraries(
+        dynmem_test
+        gtest_main
+    )
+
+    add_executable(nsnvmhelper_test EXCLUDE_FROM_ALL
+        source/nvmHelper/ns_nvm_helper.c
+        test/nsnvmhelper/nsnvmhelper_test.cpp
+        test/nsnvmhelper/test_ns_nvm_helper.c
+        test/nsnvmhelper/test_ns_nvm_helper.h
+        test/stubs/platform_nvm_stub.c
+        test/stubs/nsdynmemLIB_stub.c
+        test/stubs/ns_list_stub.c
+    )
+    # make check, this must be after add_executable!
+    add_test(nsnvmhelper_test nsnvmhelper_test)
+    if (TARGET check)
+        add_dependencies(check nsnvmhelper_test)
+    else()
+        add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
+                    DEPENDS nsnvmhelper_test)
+    endif()
+
+    target_include_directories(nsnvmhelper_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice)
+    target_include_directories(nsnvmhelper_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice/platform)
+
+    target_link_libraries(
+        nsnvmhelper_test
+        gtest_main
+    )
+
+    # GTest framework requires C++ version 11
+    set_target_properties(dynmem_test ip6tos_test stoip6_test nsnvmhelper_test
+    PROPERTIES
+        CXX_STANDARD 11
+    )
+
+    include(GoogleTest)
+    gtest_discover_tests(ip6tos_test EXTRA_ARGS --gtest_output=xml: XML_OUTPUT_DIR ip6tos)
+    gtest_discover_tests(stoip6_test EXTRA_ARGS --gtest_output=xml: XML_OUTPUT_DIR stoip6)
+    gtest_discover_tests(dynmem_test EXTRA_ARGS --gtest_output=xml: XML_OUTPUT_DIR nsdynmem)
+    gtest_discover_tests(nsnvmhelper_test EXTRA_ARGS --gtest_output=xml: XML_OUTPUT_DIR nvmhelper)
+
+    if (enable_coverage_data AND ${CMAKE_PROJECT_NAME} STREQUAL "nanostack-libservice")
+        file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html")
+
+        add_test(NAME ls_cov WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMAND ${BASH} -c "gcovr -r . -e ${CMAKE_CURRENT_SOURCE_DIR}/build -e '.*test.*' --html --html-details -o build/html/coverity_index.html"
+        )
+    endif ()
+endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,19 +40,13 @@ if (test_all OR ${CMAKE_PROJECT_NAME} STREQUAL "nanostack-libservice")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
     endif ()
 
-    add_executable(ip6tos_test EXCLUDE_FROM_ALL
+    add_executable(ip6tos_test
         source/libip6string/ip6tos.c
         source/libBits/common_functions.c
         test/ip6tos/ip6tos_test.cpp
     )
-    # make check, this must be after add_executable!
+
     add_test(ip6tos_test ip6tos_test)
-    if (TARGET check)
-        add_dependencies(check ip6tos_test)
-    else()
-        add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
-                    DEPENDS ip6tos_test)
-    endif()
 
     target_include_directories(ip6tos_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice)
     target_include_directories(ip6tos_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice/platform)
@@ -64,19 +58,13 @@ if (test_all OR ${CMAKE_PROJECT_NAME} STREQUAL "nanostack-libservice")
 
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/test/stubs)
 
-    add_executable(stoip6_test EXCLUDE_FROM_ALL
+    add_executable(stoip6_test
         source/libip6string/stoip6.c
         source/libBits/common_functions.c
         test/stoip6/stoip6_test.cpp
     )
-    # make check, this must be after add_executable!
+
     add_test(stoip6_test stoip6_test)
-    if (TARGET check)
-        add_dependencies(check stoip6_test)
-    else()
-        add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
-                    DEPENDS stoip6_test)
-    endif()
 
     target_include_directories(stoip6_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice)
     target_include_directories(stoip6_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice/platform)
@@ -86,7 +74,7 @@ if (test_all OR ${CMAKE_PROJECT_NAME} STREQUAL "nanostack-libservice")
         gtest_main
     )
 
-    add_executable(dynmem_test EXCLUDE_FROM_ALL
+    add_executable(dynmem_test
         source/nsdynmemLIB/nsdynmemLIB.c
         test/nsdynmem/dynmem_test.cpp
         test/nsdynmem/error_callback.c
@@ -94,14 +82,8 @@ if (test_all OR ${CMAKE_PROJECT_NAME} STREQUAL "nanostack-libservice")
         test/stubs/platform_critical.c
         test/stubs/ns_list_stub.c
     )
-    # make check, this must be after add_executable!
+
     add_test(dynmem_test dynmem_test)
-    if (TARGET check)
-        add_dependencies(check dynmem_test)
-    else()
-        add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
-                    DEPENDS dynmem_test)
-    endif()
 
     target_include_directories(dynmem_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice)
     target_include_directories(dynmem_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice/platform)
@@ -111,7 +93,7 @@ if (test_all OR ${CMAKE_PROJECT_NAME} STREQUAL "nanostack-libservice")
         gtest_main
     )
 
-    add_executable(nsnvmhelper_test EXCLUDE_FROM_ALL
+    add_executable(nsnvmhelper_test
         source/nvmHelper/ns_nvm_helper.c
         test/nsnvmhelper/nsnvmhelper_test.cpp
         test/nsnvmhelper/test_ns_nvm_helper.c
@@ -120,14 +102,6 @@ if (test_all OR ${CMAKE_PROJECT_NAME} STREQUAL "nanostack-libservice")
         test/stubs/nsdynmemLIB_stub.c
         test/stubs/ns_list_stub.c
     )
-    # make check, this must be after add_executable!
-    add_test(nsnvmhelper_test nsnvmhelper_test)
-    if (TARGET check)
-        add_dependencies(check nsnvmhelper_test)
-    else()
-        add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
-                    DEPENDS nsnvmhelper_test)
-    endif()
 
     target_include_directories(nsnvmhelper_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice)
     target_include_directories(nsnvmhelper_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice/platform)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ set(LS_SOURCES
 add_library(nanostack-libservice
     ${LS_SOURCES})
 
+add_library(nanostack-libserviceInterface INTERFACE)
+target_include_directories(nanostack-libserviceInterface INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-libservice)
+
 # some other projects include libservice stuff with path
 target_include_directories(nanostack-libservice PUBLIC ${nanostack-libservice_SOURCE_DIR})
 target_include_directories(nanostack-libservice PUBLIC ${nanostack-libservice_SOURCE_DIR}/mbed-client-libservice)

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -26,5 +26,5 @@ TEST_DIR="build"
 
 mkdir -p ${TEST_DIR}
 cd ${TEST_DIR}
-cmake .. -DCMAKE_BUILD_TYPE=Debug -Denable_coverage_data=ON
-make check
+cmake .. -DCMAKE_BUILD_TYPE=Debug -Denable_coverage_data=ON -Dtest_all=ON
+make all test

--- a/test/README.md
+++ b/test/README.md
@@ -18,7 +18,7 @@ sudo apt-get install gcovr
 
 ## Building and running
 
-Prepare unit test build with `cmake ..` and then run the test with `make check` as follows:
+Prepare unit test build with `cmake ..` and then run the test with `make all test` as follows:
 
 ```
 # clone repository if needed
@@ -28,7 +28,7 @@ mkdir build
 cd build
 cmake ..
 
-make check
+make all test
 ```
 
 ### Code coverage


### PR DESCRIPTION
- exposed nanostack-libserviceInterface
- limit tests creation only when test_all flag is ON or when cmake from current directory
- do not exclude tests from "make all"
- removed check target